### PR TITLE
trepan plugin updates

### DIFF
--- a/lib/Enbugger/trepan.pm
+++ b/lib/Enbugger/trepan.pm
@@ -86,10 +86,10 @@ sub _stop {
 
 1 if $DB::OUT;
 sub _write {
-    my $class = shift @_;
 
-    print { $DB::OUT } @_;
-
+    for my $c (@DB::clients) {
+	$c->output(@_);
+    }
     return;
 }
 
@@ -111,7 +111,7 @@ sub _write {
 1 if %Enbugger::RegisteredDebuggers;
 $Enbugger::RegisteredDebuggers{trepan}{symbols} = [qw[
     DB
-    sub
+    subs
     eval_with_return
     save
 ]];

--- a/lib/Enbugger/trepan.pm
+++ b/lib/Enbugger/trepan.pm
@@ -72,6 +72,7 @@ sub _stop {
     $DB::signal = 2;
     # Use at least the default debug flags.
     $^P |= 0x33f;
+    $DB::event = 'debugger-call';
     $DB::in_debugger = 0;
     return;
 }

--- a/lib/Enbugger/trepan.pm
+++ b/lib/Enbugger/trepan.pm
@@ -28,8 +28,6 @@ use vars qw( @ISA @Symbols );
 BEGIN { @ISA = 'Enbugger' }
 
 
-
-
 =head1 OVERRIDEN METHODS
 
 =over
@@ -43,6 +41,7 @@ sub _load_debugger {
 
     $class->_compile_with_nextstate();
     require Devel::Trepan::Core;
+    $^P |= 0x73f;
     $class->_compile_with_dbstate();
 
     $class->init_debugger;
@@ -70,9 +69,14 @@ sub _stop {
     # trepan looks for these to stop.
     $DB::in_debugger = 1;
     $DB::signal = 2;
-    # Use at least the default debug flags.
-    $^P |= 0x33f;
+    # Use at least the default debug flags and 
+    # eval string saving.
+    $^P |= 0x73f;
     $DB::event = 'debugger-call';
+    my ($pkg, $filename, $line) = caller;
+    if ($filename =~ /^\(eval \d+\)/) {
+	@DB::dbline = map "$_\n", split(/\n/, $DB::eval_string);
+    }
     $DB::in_debugger = 0;
     return;
 }


### PR DESCRIPTION
Hi - 

A couple more patches to consider for the _trepan.pm_ plugin.

The first patch "Correct how writes work" is a bug fix. _Devel::Trepan_ handles output differently than _perl5db_ and I previously just had cut and pasted the _perl5db_ code. My bad.

The second patch is a slight feature improvement for _Devel::Trepan_. The records why you are in the debugger, for example:
1.  you were a stepping/nexting commands
2.  you hit a temporary breakpoint
3.  you hit a perminant breakpoint
4.  a signal was handled
5.  a fatal exception (post-mortem debugging)

To this list of events I had added an explicit call to the debugger, that is `Enbugger->stop`. The second patch just notes this event properly.

The third patch is to make calling the debugger from inside a _Devel::REPL_ shell work slightly better. In particular it populates the `@DB:dbline` array so that inside the debuger you see what the eval string that is being run. The _Devel::REPL_ plugin does this by setting global `$DB::eval_string` for the plugin to pick up and use. Also I set `$^P` to save source code lines which was missing before.
