### PR TITLE
Add @Enbugger::ignore_module_pats to not process sets of Modules.

### DIFF
--- a/lib/Enbugger/trepan.pm
+++ b/lib/Enbugger/trepan.pm
@@ -39,6 +39,7 @@ BEGIN { @ISA = 'Enbugger' }
 sub _load_debugger {
     my ( $class ) = @_;
 
+    @Enbugger::ignore_module_pats = ('Devel/Trepan');
     $class->_compile_with_nextstate();
     require Devel::Trepan::Core;
     $^P |= 0x73f;


### PR DESCRIPTION
Part of this request eliminates: 

> Use of uninitialized value in subroutine entry at ... Enbugger.pm line 475.

You get this message when the debugger is not a single file as is the case for perl5db.pl. In those situations, several files are compiled with nextstate and thus don't have the source file hash set. 

The other part of this merge goes back to an older pull request. Here, we allow the debugger to register a list of patterns to ignore loading. Again this is for debuggers which span more than one file. I thought I might be able to avoid changing _Enbugger.pm_ by fiddling with `%INC%` before and after the call, but this doesn't work because debugger code can get required in late in the game. So the exclusion testing needs to be done closer to the point where reading the source occurs. 
