### PR TITLE
Don't load source Enbugger and its sub-modules

### DIFF
--- a/lib/Enbugger/trepan.pm
+++ b/lib/Enbugger/trepan.pm
@@ -39,7 +39,8 @@ BEGIN { @ISA = 'Enbugger' }
 sub _load_debugger {
     my ( $class ) = @_;
 
-    @Enbugger::ignore_module_pats = ('Devel/Trepan');
+    @Enbugger::ignore_module_pats =
+      qw(/Devel/Trepan /Enbugger/ /Enbugger.pm);
     $class->_compile_with_nextstate();
     require Devel::Trepan::Core;
     $^P |= 0x73f;
@@ -70,7 +71,7 @@ sub _stop {
     # trepan looks for these to stop.
     $DB::in_debugger = 1;
     $DB::signal = 2;
-    # Use at least the default debug flags and 
+    # Use at least the default debug flags and
     # eval string saving.
     $^P |= 0x73f;
     $DB::event = 'debugger-call';


### PR DESCRIPTION
The merge has _Enbugger_ not to run load_source on _Enbugger.pm_ or any of its sub-modules. This could be done in _perl5db.pl_ as well, although this patch doesn't do that. 

To get a sense of how many extraneous files files are loaded even with perl5db.pl put a _print_ statement in _load_file_. 

Down the line, it would be cooler is to delay loading and make it lazy. The [feature suggested](https://github.com/jbenjore/Enbugger/issues/8) is directed towards that goal. 
